### PR TITLE
Added "init" method to reuse existing cookie

### DIFF
--- a/dist/demo.js
+++ b/dist/demo.js
@@ -13,6 +13,7 @@ window.onload = function() {
 
   submitButton.onclick = function(event) {
     event.preventDefault();
+    console.log('Login button has been clicked.');
 
     const email = document.getElementById('wire-login-form-email').value;
     const password = document.getElementById('wire-login-form-password').value;
@@ -29,7 +30,14 @@ window.onload = function() {
       console.log('Received notification via WebSocket', notification);
     });
 
-    client.login(login)
+    return Promise.resolve()
+      .then(() => {
+        // Trying to login (works only if there is already a valid cookie stored in the browser)
+        return client.init();
+      })
+      .catch((error) => {
+        return client.login(login);
+      })
       .then((result) => {
         console.log('Login successful', result);
         submitButton.className = 'valid';

--- a/src/ts/core/WireAPIClient.ts
+++ b/src/ts/core/WireAPIClient.ts
@@ -40,6 +40,10 @@ export default class WireAPIClient extends EventEmitter {
     this.team.api = new TeamAPI(this.client.http);
   }
 
+  public init(): Promise<AccessTokenData> {
+    return this.refreshAccessToken();
+  }
+
   public login(data: LoginData): Promise<AccessTokenData> {
     return this.auth.api
       .postLogin(data)
@@ -51,11 +55,12 @@ export default class WireAPIClient extends EventEmitter {
   }
 
   public refreshAccessToken(): Promise<AccessTokenData> {
-    return this.auth.api.postAccess().then((accessToken: AccessTokenData) => {
-      this.client.http.accessToken = accessToken;
-      this.client.ws.accessToken = this.client.http.accessToken;
-      return accessToken;
-    });
+    return this.auth.api.postAccess()
+      .then((accessToken: AccessTokenData) => {
+        this.client.http.accessToken = accessToken;
+        this.client.ws.accessToken = this.client.http.accessToken;
+        return accessToken;
+      });
   }
 
   public connect(clientId: string): Promise<void> {


### PR DESCRIPTION
To test it you need to start Chrome with the following flags:

```
"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --disable-web-security --user-data-dir="C:\bla"
```

1. Afterwards you can start the HTML demo page (`npm start`)
2. Then you need to login providing your email address and password
3. Refresh the demo page now
4. Click on the login button (without supplying your email & password)
5. Login should work because of the `init` method 😃 