### PR TITLE
refactor: Simplified import patterns

### DIFF
--- a/src/ts/auth/AuthAPI.ts
+++ b/src/ts/auth/AuthAPI.ts
@@ -1,8 +1,7 @@
 import {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios';
 
-import AccessTokenData from './AccessTokenData';
 import HttpClient from '../http/HttpClient';
-import LoginData from './LoginData';
+import {AccessTokenData, LoginData} from '../auth';
 
 export default class AuthAPI {
   constructor(private client: HttpClient) {}

--- a/src/ts/auth/AuthAPI.ts
+++ b/src/ts/auth/AuthAPI.ts
@@ -1,6 +1,6 @@
 import {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios';
 
-import * as auth from '../auth';
+import {AccessTokenData, LoginData} from '../auth';
 import {HttpClient} from '../http';
 
 export default class AuthAPI {
@@ -18,7 +18,7 @@ export default class AuthAPI {
     };
   }
 
-  public postCookiesRemove(login: auth.LoginData, labels?: string[]): AxiosPromise {
+  public postCookiesRemove(login: LoginData, labels?: string[]): AxiosPromise {
     const config: AxiosRequestConfig = {
       data: {
         labels: labels,
@@ -31,7 +31,7 @@ export default class AuthAPI {
     return this.client.sendRequest(config);
   }
 
-  public postLogin(login: auth.LoginData): Promise<auth.AccessTokenData> {
+  public postLogin(login: LoginData): Promise<AccessTokenData> {
     login.password = login.password.toString();
     const config: AxiosRequestConfig = {
       data: login,
@@ -61,7 +61,7 @@ export default class AuthAPI {
       });
   }
 
-  public postAccess(): Promise<auth.AccessTokenData> {
+  public postAccess(): Promise<AccessTokenData> {
     const config: AxiosRequestConfig = {
       withCredentials: true,
       method: 'post',

--- a/src/ts/auth/AuthAPI.ts
+++ b/src/ts/auth/AuthAPI.ts
@@ -1,7 +1,7 @@
 import {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios';
 
-import HttpClient from '../http/HttpClient';
-import {AccessTokenData, LoginData} from '../auth';
+import * as auth from '../auth';
+import {HttpClient} from '../http';
 
 export default class AuthAPI {
   constructor(private client: HttpClient) {}
@@ -18,7 +18,7 @@ export default class AuthAPI {
     };
   }
 
-  public postCookiesRemove(login: LoginData, labels?: string[]): AxiosPromise {
+  public postCookiesRemove(login: auth.LoginData, labels?: string[]): AxiosPromise {
     const config: AxiosRequestConfig = {
       data: {
         labels: labels,
@@ -31,7 +31,7 @@ export default class AuthAPI {
     return this.client.sendRequest(config);
   }
 
-  public postLogin(login: LoginData): Promise<AccessTokenData> {
+  public postLogin(login: auth.LoginData): Promise<auth.AccessTokenData> {
     login.password = login.password.toString();
     const config: AxiosRequestConfig = {
       data: login,
@@ -61,7 +61,7 @@ export default class AuthAPI {
       });
   }
 
-  public postAccess(): Promise<AccessTokenData> {
+  public postAccess(): Promise<auth.AccessTokenData> {
     const config: AxiosRequestConfig = {
       withCredentials: true,
       method: 'post',

--- a/src/ts/auth/index.ts
+++ b/src/ts/auth/index.ts
@@ -1,0 +1,9 @@
+import AccessTokenData from './AccessTokenData';
+import AuthAPI from './AuthAPI';
+import LoginData from './LoginData';
+
+export {
+  AccessTokenData,
+  AuthAPI,
+  LoginData,
+}

--- a/src/ts/core/WireAPIClient.ts
+++ b/src/ts/core/WireAPIClient.ts
@@ -1,12 +1,12 @@
 import * as WebSocket from 'ws';
 import EventEmitter = require('events');
 
-import Context from './Context';
-import HttpClient from '../http/HttpClient';
-import TeamAPI from '../team/TeamAPI';
-import WebSocketClient from '../tcp/WebSocketClient';
 import {AccessTokenData, AuthAPI, LoginData} from '../auth';
+import {Context} from '../core';
+import {HttpClient} from '../http';
+import {TeamAPI} from '../team';
 import {UserAPI, UserData} from  '../user';
+import {WebSocketClient} from '../tcp';
 
 export default class WireAPIClient extends EventEmitter {
   public auth: {api: AuthAPI} = {

--- a/src/ts/core/WireAPIClient.ts
+++ b/src/ts/core/WireAPIClient.ts
@@ -1,13 +1,11 @@
 import * as WebSocket from 'ws';
 import EventEmitter = require('events');
 
-import AccessTokenData from '../auth/AccessTokenData';
-import AuthAPI from '../auth/AuthAPI';
 import Context from './Context';
 import HttpClient from '../http/HttpClient';
-import LoginData from '../auth/LoginData';
 import TeamAPI from '../team/TeamAPI';
 import WebSocketClient from '../tcp/WebSocketClient';
+import {AccessTokenData, AuthAPI, LoginData} from '../auth';
 import {UserAPI, UserData} from  '../user';
 
 export default class WireAPIClient extends EventEmitter {

--- a/src/ts/core/index.ts
+++ b/src/ts/core/index.ts
@@ -1,0 +1,7 @@
+import Context from './Context';
+import WireAPIClient from './WireAPIClient';
+
+export {
+  Context,
+  WireAPIClient
+}

--- a/src/ts/http/HttpClient.ts
+++ b/src/ts/http/HttpClient.ts
@@ -1,7 +1,7 @@
 import axios, {AxiosPromise, AxiosRequestConfig} from 'axios';
 
-import AccessTokenData from '../auth/AccessTokenData';
-import ContentType from './ContentType';
+import {AccessTokenData} from '../auth';
+import {ContentType} from '../http';
 
 export default class HttpClient {
   public accessToken: AccessTokenData = undefined;

--- a/src/ts/http/index.ts
+++ b/src/ts/http/index.ts
@@ -1,7 +1,9 @@
 import ContentType from './ContentType';
+import HttpClient from './HttpClient';
 import StatusCode from './StatusCode';
 
-module.exports = {
-  ContentType: ContentType,
-  StatusCode: StatusCode,
+export {
+  ContentType,
+  HttpClient,
+  StatusCode,
 };

--- a/src/ts/tcp/WebSocketClient.ts
+++ b/src/ts/tcp/WebSocketClient.ts
@@ -1,6 +1,6 @@
 import * as WebSocket from 'ws';
 
-import AccessTokenData from '../auth/AccessTokenData';
+import {AccessTokenData} from '../auth';
 
 export default class WebSocketClient {
   public accessToken: AccessTokenData;

--- a/src/ts/tcp/index.ts
+++ b/src/ts/tcp/index.ts
@@ -1,0 +1,5 @@
+import WebSocketClient from './WebSocketClient';
+
+export {
+  WebSocketClient
+};

--- a/src/ts/team/TeamAPI.ts
+++ b/src/ts/team/TeamAPI.ts
@@ -1,10 +1,7 @@
 import {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios';
 
-import HttpClient from '../http/HttpClient';
-import MemberData from './MemberData';
-import NewTeamData from './NewTeamData';
-import TeamChunkData from './TeamChunkData';
-import TeamData from './TeamData';
+import * as team from '../team';
+import {HttpClient} from '../http';
 
 export default class TeamAPI {
   constructor(private client: HttpClient) {}
@@ -16,7 +13,7 @@ export default class TeamAPI {
     };
   }
 
-  public postTeam(team: NewTeamData): AxiosPromise {
+  public postTeam(team: team.NewTeamData): AxiosPromise {
     const config: AxiosRequestConfig = {
       data: {
         name: team.name,
@@ -33,7 +30,7 @@ export default class TeamAPI {
       });
   }
 
-  public putTeam(team: TeamData): AxiosPromise {
+  public putTeam(team: team.TeamData): AxiosPromise {
     const config: AxiosRequestConfig = {
       data: {
         name: team.name,
@@ -50,7 +47,7 @@ export default class TeamAPI {
       });
   }
 
-  public getTeams(): Promise<TeamChunkData> {
+  public getTeams(): Promise<team.TeamChunkData> {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: `${TeamAPI.URL.TEAMS}`,
@@ -63,7 +60,7 @@ export default class TeamAPI {
       });
   }
 
-  public getTeam(teamId: string): Promise<TeamData> {
+  public getTeam(teamId: string): Promise<team.TeamData> {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: `${TeamAPI.URL.TEAMS}/${teamId}`,
@@ -89,7 +86,7 @@ export default class TeamAPI {
       });
   }
 
-  public getMembers(teamId: string): Promise<MemberData[]> {
+  public getMembers(teamId: string): Promise<team.MemberData[]> {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: `${TeamAPI.URL.TEAMS}/${teamId}/${TeamAPI.URL.MEMBERS}`,
@@ -115,7 +112,7 @@ export default class TeamAPI {
       });
   }
 
-  public postMembers(teamId: string, member: MemberData): AxiosPromise {
+  public postMembers(teamId: string, member: team.MemberData): AxiosPromise {
     const config: AxiosRequestConfig = {
       data: {
         member: member,
@@ -131,7 +128,7 @@ export default class TeamAPI {
       });
   }
 
-  public putMembers(teamId: string, member: MemberData): AxiosPromise {
+  public putMembers(teamId: string, member: team.MemberData): AxiosPromise {
     const config: AxiosRequestConfig = {
       data: {
         member: member,

--- a/src/ts/team/TeamAPI.ts
+++ b/src/ts/team/TeamAPI.ts
@@ -1,6 +1,6 @@
 import {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios';
 
-import * as team from '../team';
+import {MemberData, NewTeamData, TeamChunkData, TeamData} from '../team';
 import {HttpClient} from '../http';
 
 export default class TeamAPI {
@@ -13,7 +13,7 @@ export default class TeamAPI {
     };
   }
 
-  public postTeam(team: team.NewTeamData): AxiosPromise {
+  public postTeam(team: NewTeamData): AxiosPromise {
     const config: AxiosRequestConfig = {
       data: {
         name: team.name,
@@ -30,7 +30,7 @@ export default class TeamAPI {
       });
   }
 
-  public putTeam(team: team.TeamData): AxiosPromise {
+  public putTeam(team: TeamData): AxiosPromise {
     const config: AxiosRequestConfig = {
       data: {
         name: team.name,
@@ -47,7 +47,7 @@ export default class TeamAPI {
       });
   }
 
-  public getTeams(): Promise<team.TeamChunkData> {
+  public getTeams(): Promise<TeamChunkData> {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: `${TeamAPI.URL.TEAMS}`,
@@ -60,7 +60,7 @@ export default class TeamAPI {
       });
   }
 
-  public getTeam(teamId: string): Promise<team.TeamData> {
+  public getTeam(teamId: string): Promise<TeamData> {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: `${TeamAPI.URL.TEAMS}/${teamId}`,
@@ -86,7 +86,7 @@ export default class TeamAPI {
       });
   }
 
-  public getMembers(teamId: string): Promise<team.MemberData[]> {
+  public getMembers(teamId: string): Promise<MemberData[]> {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: `${TeamAPI.URL.TEAMS}/${teamId}/${TeamAPI.URL.MEMBERS}`,
@@ -112,7 +112,7 @@ export default class TeamAPI {
       });
   }
 
-  public postMembers(teamId: string, member: team.MemberData): AxiosPromise {
+  public postMembers(teamId: string, member: MemberData): AxiosPromise {
     const config: AxiosRequestConfig = {
       data: {
         member: member,
@@ -128,7 +128,7 @@ export default class TeamAPI {
       });
   }
 
-  public putMembers(teamId: string, member: team.MemberData): AxiosPromise {
+  public putMembers(teamId: string, member: MemberData): AxiosPromise {
     const config: AxiosRequestConfig = {
       data: {
         member: member,

--- a/src/ts/team/index.ts
+++ b/src/ts/team/index.ts
@@ -1,0 +1,15 @@
+import MemberData from './MemberData';
+import NewTeamData from './NewTeamData';
+import PermissionsData from './PermissionsData';
+import TeamAPI from './TeamAPI';
+import TeamChunkData from './TeamChunkData';
+import TeamData from './TeamData';
+
+export {
+  MemberData,
+  NewTeamData,
+  PermissionsData,
+  TeamAPI,
+  TeamChunkData,
+  TeamData
+};

--- a/src/ts/user/UserAPI.ts
+++ b/src/ts/user/UserAPI.ts
@@ -1,7 +1,7 @@
 import {AxiosRequestConfig, AxiosResponse} from 'axios';
 
-import HttpClient from '../http/HttpClient';
-import UserData from './UserData';
+import {HttpClient} from '../http';
+import {UserData} from '../user';
 
 export default class UserAPI {
   constructor(private client: HttpClient) {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "declaration": true,
     "lib": [
       "DOM",
@@ -11,6 +12,11 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "outDir": "dist/commonjs",
+    "paths": {
+      "*": [
+        "./src/ts/*"
+      ]
+    },
     "removeComments": true,
     "rootDir": "src/ts",
     "sourceMap": false,


### PR DESCRIPTION
I turned things like this:

```ts
import AccessTokenData from '../auth/AccessTokenData';
import AuthAPI from '../auth/AuthAPI';
import LoginData from '../auth/LoginData';
```

Into this:
 
```ts
import {AccessTokenData, AuthAPI, LoginData} from '../auth';
```